### PR TITLE
feat: use lowlevel server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-google-cse"
-version = "0.1.3"
+version = "0.1.4"
 description = "An MCP server for searching a custom Google search engine."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -28,4 +28,4 @@ Homepage = "https://github.com/Richard-Weiss/mcp-google-cse"
 Issues = "https://github.com/Richard-Weiss/mcp-google-cse/issues"
 
 [project.scripts]
-mcp-google-cse = "mcp_google_cse.server:main"
+mcp-google-cse = "mcp_google_cse:main"

--- a/src/mcp_google_cse/__init__.py
+++ b/src/mcp_google_cse/__init__.py
@@ -1,0 +1,10 @@
+import asyncio
+from . import server
+
+
+def main():
+    """Main entry point for the package."""
+    asyncio.run(server.run())
+
+
+__all__ = ['main', 'server']

--- a/src/mcp_google_cse/__main__.py
+++ b/src/mcp_google_cse/__main__.py
@@ -1,0 +1,3 @@
+from mcp_google_cse import main
+
+main()

--- a/src/mcp_google_cse/server.py
+++ b/src/mcp_google_cse/server.py
@@ -1,20 +1,59 @@
 import os
+from sys import stdin, stdout
 from typing import Any, List
 
 from googleapiclient.discovery import build
-from mcp.server.fastmcp import FastMCP
+from mcp import Tool, stdio_server
+from mcp.server.lowlevel import Server
+from mcp.types import TextContent, ImageContent, EmbeddedResource
 
-mcp = FastMCP("mcp-google-cse")
+stdin.reconfigure(encoding='utf-8')
+stdout.reconfigure(encoding='utf-8')
+
+server = Server("mcp-google-cse")
 
 
-@mcp.tool()
-def google_search(search_term: str) -> Any:
+@server.list_tools()
+async def handle_list_tools() -> list[Tool]:
+    """
+    List available tools.
+    Each tool specifies its arguments using JSON Schema validation.
+    """
+    return [
+        Tool(
+            name="google_search",
+            description="Search the custom search engine using the search term. Regular query arguments can also be used, like appending site:reddit.com or after:2024-04-30. If available and/or requested, the links of the search results should be used in a follow-up request using a different tool to get the full content. Example: \"claude.ai features site:reddit.com after:2024-04-30\"",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "search_term": {"type": "string"},
+                },
+                "required": ["search_term"],
+            }
+        )
+    ]
+
+
+@server.call_tool()
+async def handle_call_tool(
+        name: str, arguments: dict[str, Any] | None
+) -> list[TextContent | ImageContent | EmbeddedResource]:
+    """
+    Handle tool execution requests.
+    Tools can modify server state and notify clients of changes.
+    """
+    search_term = arguments.get('search_term', '')
+
+    if name == 'google_search' and search_term != '':
+        result = await google_search(search_term)
+        return result
+    else:
+        raise ValueError(f"Unknown tool: {name}")
+
+
+async def google_search(search_term: str) -> List[TextContent]:
     """
     Search the custom search engine using the search term.
-    Regular query arguments can also be used, like appending site:reddit.com or after:2024-04-30.
-    If available and/or requested, the links of the search results should be used
-    in a follow-up request using a different tool to get the full content.
-    Example: "claude.ai features site:reddit.com after:2024-04-30"
     :param search_term: The search term to search for, equaling the q argument in Google's search.
     :return: Search results containing the title, link and snippet of the search result.
     """
@@ -29,7 +68,18 @@ def google_search(search_term: str) -> Any:
         fields='items(title,link,snippet)').execute()
     results = response['items']
     __clean_up_snippets(results)
-    return results
+
+    text_contents = []
+
+    for result in results:
+        text_contents.append(
+            TextContent(
+                type="text",
+                text=f"Title: {result['title']}\nLink: {result['link']}\nSnippet: {result['snippet']}"
+            )
+        )
+
+    return text_contents
 
 
 def __clean_up_snippets(items: List[dict]) -> None:
@@ -42,5 +92,11 @@ def __clean_up_snippets(items: List[dict]) -> None:
         item.update({k: v.replace('\xa0', ' ').strip() if k == 'snippet' else v for k, v in item.items()})
 
 
-def main():
-    mcp.run()
+async def run() -> None:
+    options = server.create_initialization_options()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            options
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -274,7 +274,7 @@ wheels = [
 
 [[package]]
 name = "mcp-google-cse"
-version = "0.1.0"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "google-api-python-client" },


### PR DESCRIPTION
Fixes #2
Use the lowlevel MCP server so encoding mitigation works. FastMCP messes up the encoding and previous mitigations don't work with it.